### PR TITLE
Refactor OpenAI provider to OpenRouter provider and add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# OpenRouter AI Provider for Moodle
+
+This plugin integrates the [OpenRouter](https://openrouter.ai/) API with Moodle's Core AI framework, enabling text generation, text summarisation, and image generation actions from Moodle placements.
+
+## Features
+- Supports the core AI actions `generate_text`, `summarise_text`, and `generate_image`.
+- Configurable per-action model selection and endpoint URLs.
+- Adds the required OpenRouter headers (`Authorization`, `HTTP-Referer`, `X-Title`) automatically.
+- Optional global and per-user rate limiting using Moodle's built-in rate limiter.
+- Unit tests covering provider authentication, request construction, rate-limiting, and response handling pathways.
+
+## Requirements
+- Moodle 4.5 (build 2024100100) or later.
+- An active OpenRouter account with a valid API key.
+
+## Installation
+1. Copy the `openrouter` directory into `moodle/ai/provider/`.
+2. Visit `Site administration → Notifications` to trigger the plugin installation and database upgrade.
+
+## Configuration
+Navigate to `Site administration → Plugins → AI → OpenRouter API provider` and configure:
+
+- **OpenRouter API key** – create a key in your OpenRouter account and paste it here.
+- **HTTP-Referer header** – required by OpenRouter; set this to the public URL of your Moodle site (for example `https://example.edu`).
+- **X-Title header** – optional friendly name displayed in your OpenRouter dashboard (defaults to the Moodle site name).
+- **Per-action settings** – for each supported action you can define the default model (e.g. `openrouter/auto` or `openai/dall-e-3`), endpoint URL, and system instructions.
+- **Rate limits** – optionally enable and configure global or per-user hourly request caps.
+
+After saving the settings, ensure that each AI placement selects OpenRouter as its provider and chooses the appropriate action.
+
+## Testing
+Automated tests live under the `tests/` directory and exercise the provider, processors, and rate-limiter behaviour. From the Moodle root you can run:
+
+```bash
+vendor/bin/phpunit ai/provider/openrouter/tests
+```
+
+*(Depending on your environment you may need to install PHPUnit via Composer first.)*
+
+## Support
+For questions specific to this Moodle integration, contact the e-Learning Team at Universiti Malaysia Terengganu: `el@umt.edu.my`.
+

--- a/classes/abstract_processor.php
+++ b/classes/abstract_processor.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace aiprovider_openai;
+namespace aiprovider_openrouter;
 
 use core\http_client;
 use core_ai\aiactions\responses\response_base;
@@ -28,7 +28,8 @@ use Psr\Http\Message\UriInterface;
 /**
  * Class process text generation.
  *
- * @package    aiprovider_openai
+ * @package    aiprovider_openrouter
+ * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
  * @copyright  2024 Matt Porritt <matt.porritt@moodle.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace aiprovider_openai\privacy;
+namespace aiprovider_openrouter\privacy;
 
 use core_privacy\local\metadata\collection;
 use core_privacy\local\request\approved_contextlist;
@@ -23,9 +23,10 @@ use core_privacy\local\request\contextlist;
 use core_privacy\local\request\userlist;
 
 /**
- * Privacy provider implementation for OpenAI provider
+ * Privacy provider implementation for OpenRouter provider
  *
- * @package    aiprovider_openai
+ * @package    aiprovider_openrouter
+ * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
  * @copyright  2024 Matt Porritt <matt.porritt@moodle.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @codeCoverageIgnore
@@ -36,12 +37,12 @@ class provider implements
     \core_privacy\local\request\plugin\provider {
     #[\Override]
     public static function get_metadata(collection $collection): collection {
-        $collection->add_external_location_link('aiprovider_openai', [
-            'prompttext' => 'privacy:metadata:aiprovider_openai:prompttext',
-            'model' => 'privacy:metadata:aiprovider_openai:model',
-            'numberimages' => 'privacy:metadata:aiprovider_openai:numberimages',
-            'responseformat' => 'privacy:metadata:aiprovider_openai:responseformat',
-        ], 'privacy:metadata:aiprovider_openai:externalpurpose');
+        $collection->add_external_location_link('aiprovider_openrouter', [
+            'prompttext' => 'privacy:metadata:aiprovider_openrouter:prompttext',
+            'model' => 'privacy:metadata:aiprovider_openrouter:model',
+            'numberimages' => 'privacy:metadata:aiprovider_openrouter:numberimages',
+            'responseformat' => 'privacy:metadata:aiprovider_openrouter:responseformat',
+        ], 'privacy:metadata:aiprovider_openrouter:externalpurpose');
         return $collection;
     }
 

--- a/classes/process_generate_image.php
+++ b/classes/process_generate_image.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace aiprovider_openai;
+namespace aiprovider_openrouter;
 
 use core\http_client;
 use core_ai\ai_image;
@@ -27,7 +27,8 @@ use Psr\Http\Message\UriInterface;
 /**
  * Class process image generation.
  *
- * @package    aiprovider_openai
+ * @package    aiprovider_openrouter
+ * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
  * @copyright  2024 Matt Porritt <matt.porritt@moodle.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -40,12 +41,12 @@ class process_generate_image extends abstract_processor {
 
     #[\Override]
     protected function get_endpoint(): UriInterface {
-        return new Uri(get_config('aiprovider_openai', 'action_generate_image_endpoint'));
+        return new Uri(get_config('aiprovider_openrouter', 'action_generate_image_endpoint'));
     }
 
     #[\Override]
     protected function get_model(): string {
-        return get_config('aiprovider_openai', 'action_generate_image_model');
+        return get_config('aiprovider_openrouter', 'action_generate_image_model');
     }
 
     #[\Override]
@@ -110,11 +111,12 @@ class process_generate_image extends abstract_processor {
     protected function handle_api_success(ResponseInterface $response): array {
         $responsebody = $response->getBody();
         $bodyobj = json_decode($responsebody->getContents());
+        $data = $bodyobj->data[0] ?? new \stdClass();
 
         return [
             'success' => true,
-            'sourceurl' => $bodyobj->data[0]->url,
-            'revisedprompt' => $bodyobj->data[0]->revised_prompt,
+            'sourceurl' => $data->url ?? '',
+            'revisedprompt' => $data->revised_prompt ?? '',
         ];
     }
 

--- a/classes/process_generate_text.php
+++ b/classes/process_generate_text.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace aiprovider_openai;
+namespace aiprovider_openrouter;
 
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
@@ -25,24 +25,25 @@ use Psr\Http\Message\UriInterface;
 /**
  * Class process text generation.
  *
- * @package    aiprovider_openai
+ * @package    aiprovider_openrouter
+ * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
  * @copyright  2024 Matt Porritt <matt.porritt@moodle.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class process_generate_text extends abstract_processor {
     #[\Override]
     protected function get_endpoint(): UriInterface {
-        return new Uri(get_config('aiprovider_openai', 'action_generate_text_endpoint'));
+        return new Uri(get_config('aiprovider_openrouter', 'action_generate_text_endpoint'));
     }
 
     #[\Override]
     protected function get_model(): string {
-        return get_config('aiprovider_openai', 'action_generate_text_model');
+        return get_config('aiprovider_openrouter', 'action_generate_text_model');
     }
 
     #[\Override]
     protected function get_system_instruction(): string {
-        return get_config('aiprovider_openai', 'action_generate_text_systeminstruction');
+        return get_config('aiprovider_openrouter', 'action_generate_text_systeminstruction');
     }
 
     #[\Override]
@@ -79,6 +80,50 @@ class process_generate_text extends abstract_processor {
     }
 
     /**
+     * Normalise assistant message content to a plain string.
+     *
+     * @param object $message The message payload.
+     * @return string
+     */
+    private function normalise_message_content(object $message): string {
+        if (!empty($message->content) && is_string($message->content)) {
+            return $message->content;
+        }
+
+        $content = $message->content ?? '';
+        $textparts = [];
+
+        // Handle array based message payloads.
+        if (is_array($content)) {
+            foreach ($content as $part) {
+                if (is_string($part)) {
+                    $textparts[] = $part;
+                } else if (is_object($part)) {
+                    if (isset($part->text) && is_string($part->text)) {
+                        $textparts[] = $part->text;
+                    } else if (isset($part->content) && is_string($part->content)) {
+                        $textparts[] = $part->content;
+                    }
+                } else if (is_array($part) && isset($part['text']) && is_string($part['text'])) {
+                    $textparts[] = $part['text'];
+                }
+            }
+        } else if (is_object($content)) {
+            if (isset($content->text) && is_string($content->text)) {
+                $textparts[] = $content->text;
+            } else if (isset($content->content) && is_string($content->content)) {
+                $textparts[] = $content->content;
+            }
+        }
+
+        if (!empty($textparts)) {
+            return implode('', $textparts);
+        }
+
+        return is_scalar($content) ? (string) $content : '';
+    }
+
+    /**
      * Handle a successful response from the external AI api.
      *
      * @param ResponseInterface $response The response object.
@@ -88,14 +133,19 @@ class process_generate_text extends abstract_processor {
         $responsebody = $response->getBody();
         $bodyobj = json_decode($responsebody->getContents());
 
+        $choice = $bodyobj->choices[0] ?? new \stdClass();
+        $message = $choice->message ?? new \stdClass();
+        $generatedcontent = $this->normalise_message_content($message);
+        $usage = $bodyobj->usage ?? new \stdClass();
+
         return [
             'success' => true,
-            'id' => $bodyobj->id,
-            'fingerprint' => $bodyobj->system_fingerprint,
-            'generatedcontent' => $bodyobj->choices[0]->message->content,
-            'finishreason' => $bodyobj->choices[0]->finish_reason,
-            'prompttokens' => $bodyobj->usage->prompt_tokens,
-            'completiontokens' => $bodyobj->usage->completion_tokens,
+            'id' => $bodyobj->id ?? '',
+            'fingerprint' => $bodyobj->system_fingerprint ?? '',
+            'generatedcontent' => $generatedcontent,
+            'finishreason' => $choice->finish_reason ?? '',
+            'prompttokens' => $usage->prompt_tokens ?? 0,
+            'completiontokens' => $usage->completion_tokens ?? 0,
         ];
     }
 }

--- a/classes/process_summarise_text.php
+++ b/classes/process_summarise_text.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace aiprovider_openai;
+namespace aiprovider_openrouter;
 
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\UriInterface;
@@ -22,23 +22,24 @@ use Psr\Http\Message\UriInterface;
 /**
  * Class process text summarisation.
  *
- * @package    aiprovider_openai
+ * @package    aiprovider_openrouter
+ * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
  * @copyright  2024 Matt Porritt <matt.porritt@moodle.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class process_summarise_text extends process_generate_text {
     #[\Override]
     protected function get_endpoint(): UriInterface {
-        return new Uri(get_config('aiprovider_openai', 'action_summarise_text_endpoint'));
+        return new Uri(get_config('aiprovider_openrouter', 'action_summarise_text_endpoint'));
     }
 
     #[\Override]
     protected function get_model(): string {
-        return get_config('aiprovider_openai', 'action_summarise_text_model');
+        return get_config('aiprovider_openrouter', 'action_summarise_text_model');
     }
 
     #[\Override]
     protected function get_system_instruction(): string {
-        return get_config('aiprovider_openai', 'action_summarise_text_systeminstruction');
+        return get_config('aiprovider_openrouter', 'action_summarise_text_systeminstruction');
     }
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -15,17 +15,30 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version information for aiprovider_openrouter.
+ * Upgrade script for the OpenRouter AI provider.
  *
  * @package    aiprovider_openrouter
  * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
- * @copyright  2024 Matt Porritt <matt.porritt@moodle.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->component = 'aiprovider_openrouter';
-$plugin->version = 2024100701;
-$plugin->requires = 2024100100;
-$plugin->maturity = MATURITY_STABLE;
+/**
+ * Execute OpenRouter AI provider upgrades.
+ *
+ * @param int $oldversion The currently installed version.
+ * @return bool
+ */
+function xmldb_aiprovider_openrouter_upgrade(int $oldversion): bool {
+    if ($oldversion < 2024100701) {
+        $legacyorgid = get_config('aiprovider_openrouter', 'orgid');
+        $httpreferer = get_config('aiprovider_openrouter', 'httpreferer');
+        if (!empty($legacyorgid) && empty($httpreferer)) {
+            set_config('httpreferer', $legacyorgid, 'aiprovider_openrouter');
+        }
+        upgrade_plugin_savepoint(true, 2024100701, 'aiprovider', 'openrouter');
+    }
+
+    return true;
+}

--- a/lang/en/aiprovider_openrouter.php
+++ b/lang/en/aiprovider_openrouter.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for component aiprovider_openrouter, language 'en'.
+ *
+ * @package    aiprovider_openrouter
+ * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
+ * @copyright  2024 Matt Porritt <matt.porritt@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['action:generate_image:endpoint'] = 'API endpoint';
+$string['action:generate_image:model'] = 'AI model';
+$string['action:generate_image:model_desc'] = 'The model used to generate images from user prompts.';
+$string['action:generate_text:endpoint'] = 'API endpoint';
+$string['action:generate_text:model'] = 'AI model';
+$string['action:generate_text:model_desc'] = 'The model used to generate the text response.';
+$string['action:generate_text:systeminstruction'] = 'System instruction';
+$string['action:generate_text:systeminstruction_desc'] = 'This instruction is sent to the AI model along with the user\'s prompt. Editing this instruction is not recommended unless absolutely required.';
+$string['action:summarise_text:endpoint'] = 'API endpoint';
+$string['action:summarise_text:model'] = 'AI model';
+$string['action:summarise_text:model_desc'] = 'The model used to summarise the provided text.';
+$string['action:summarise_text:systeminstruction'] = 'System instruction';
+$string['action:summarise_text:systeminstruction_desc'] = 'This instruction is sent to the AI model along with the user\'s prompt. Editing this instruction is not recommended unless absolutely required.';
+$string['apikey'] = 'OpenRouter API key';
+$string['apikey_desc'] = 'Generate an API key from <a href="https://openrouter.ai/keys">OpenRouter</a> and paste it here to enable requests. The key must have access to the models you configure below.';
+$string['httpreferer'] = 'HTTP-Referer header';
+$string['httpreferer_desc'] = 'OpenRouter requires requests to include the HTTP-Referer header that identifies your site. Use a fully qualified URL such as https://example.com.';
+$string['enableglobalratelimit'] = 'Set site-wide rate limit';
+$string['enableglobalratelimit_desc'] = 'Limit the number of requests that the OpenRouter API provider can receive across the entire site every hour.';
+$string['enableuserratelimit'] = 'Set user rate limit';
+$string['enableuserratelimit_desc'] = 'Limit the number of requests each user can make to the OpenRouter API provider every hour.';
+$string['globalratelimit'] = 'Maximum number of site-wide requests';
+$string['globalratelimit_desc'] = 'The number of site-wide requests allowed per hour.';
+$string['xtitle'] = 'X-Title header';
+$string['xtitle_desc'] = 'Optional: Send a friendly name for your site in the X-Title header. This appears in the OpenRouter dashboard.';
+$string['pluginname'] = 'OpenRouter API provider';
+$string['privacy:metadata'] = 'The OpenRouter API provider plugin does not store any personal data.';
+$string['privacy:metadata:aiprovider_openrouter:externalpurpose'] = 'This information is sent to the OpenRouter API in order for a response to be generated. Your OpenRouter account settings may change how OpenRouter stores and retains this data. No user data is explicitly sent to OpenRouter or stored in Moodle LMS by this plugin.';
+$string['privacy:metadata:aiprovider_openrouter:model'] = 'The model used to generate the response.';
+$string['privacy:metadata:aiprovider_openrouter:numberimages'] = 'When generating images the number of images used in the response.';
+$string['privacy:metadata:aiprovider_openrouter:prompttext'] = 'The user entered text prompt used to generate the response.';
+$string['privacy:metadata:aiprovider_openrouter:responseformat'] = 'When generating images the format of the response.';
+$string['userratelimit'] = 'Maximum number of requests per user';
+$string['userratelimit_desc'] = 'The number of requests allowed per hour, per user.';

--- a/settings.php
+++ b/settings.php
@@ -17,7 +17,8 @@
 /**
  * Plugin administration pages are defined here.
  *
- * @package     aiprovider_openai
+ * @package     aiprovider_openrouter
+ * @copyright   2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
  * @copyright   2024 Matt Porritt <matt.porritt@moodle.com>
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -26,73 +27,84 @@ use core_ai\admin\admin_settingspage_provider;
 
 defined('MOODLE_INTERNAL') || die();
 
+global $CFG;
+
 if ($hassiteconfig) {
     // Provider specific settings heading.
     $settings = new admin_settingspage_provider(
-        'aiprovider_openai',
-        new lang_string('pluginname', 'aiprovider_openai'),
+        'aiprovider_openrouter',
+        new lang_string('pluginname', 'aiprovider_openrouter'),
         'moodle/site:config',
         true,
     );
 
     $settings->add(new admin_setting_heading(
-        'aiprovider_openai/general',
+        'aiprovider_openrouter/general',
         new lang_string('settings', 'core'),
         '',
     ));
 
-    // Setting to store OpenAI API key.
+    // Setting to store OpenRouter API key.
     $settings->add(new admin_setting_configpasswordunmask(
-        'aiprovider_openai/apikey',
-        new lang_string('apikey', 'aiprovider_openai'),
-        new lang_string('apikey_desc', 'aiprovider_openai'),
+        'aiprovider_openrouter/apikey',
+        new lang_string('apikey', 'aiprovider_openrouter'),
+        new lang_string('apikey_desc', 'aiprovider_openrouter'),
         '',
     ));
 
-    // Setting to store OpenAI organization ID.
+    // Setting to store HTTP-Referer header value (required by OpenRouter).
     $settings->add(new admin_setting_configtext(
-        'aiprovider_openai/orgid',
-        new lang_string('orgid', 'aiprovider_openai'),
-        new lang_string('orgid_desc', 'aiprovider_openai'),
-        '',
+        'aiprovider_openrouter/httpreferer',
+        new lang_string('httpreferer', 'aiprovider_openrouter'),
+        new lang_string('httpreferer_desc', 'aiprovider_openrouter'),
+        $CFG->wwwroot ?? '',
+        PARAM_URL,
+    ));
+
+    // Setting to store X-Title header value (recommended by OpenRouter).
+    $settings->add(new admin_setting_configtext(
+        'aiprovider_openrouter/xtitle',
+        new lang_string('xtitle', 'aiprovider_openrouter'),
+        new lang_string('xtitle_desc', 'aiprovider_openrouter'),
+        get_config('moodle', 'sitename') ?: 'Moodle',
         PARAM_TEXT,
     ));
 
     // Setting to enable/disable global rate limiting.
     $settings->add(new admin_setting_configcheckbox(
-        'aiprovider_openai/enableglobalratelimit',
-        new lang_string('enableglobalratelimit', 'aiprovider_openai'),
-        new lang_string('enableglobalratelimit_desc', 'aiprovider_openai'),
+        'aiprovider_openrouter/enableglobalratelimit',
+        new lang_string('enableglobalratelimit', 'aiprovider_openrouter'),
+        new lang_string('enableglobalratelimit_desc', 'aiprovider_openrouter'),
         0,
     ));
 
     // Setting to set how many requests per hour are allowed for the global rate limit.
     // Should only be enabled when global rate limiting is enabled.
     $settings->add(new admin_setting_configtext(
-        'aiprovider_openai/globalratelimit',
-        new lang_string('globalratelimit', 'aiprovider_openai'),
-        new lang_string('globalratelimit_desc', 'aiprovider_openai'),
+        'aiprovider_openrouter/globalratelimit',
+        new lang_string('globalratelimit', 'aiprovider_openrouter'),
+        new lang_string('globalratelimit_desc', 'aiprovider_openrouter'),
         100,
         PARAM_INT,
     ));
-    $settings->hide_if('aiprovider_openai/globalratelimit', 'aiprovider_openai/enableglobalratelimit', 'eq', 0);
+    $settings->hide_if('aiprovider_openrouter/globalratelimit', 'aiprovider_openrouter/enableglobalratelimit', 'eq', 0);
 
     // Setting to enable/disable user rate limiting.
     $settings->add(new admin_setting_configcheckbox(
-        'aiprovider_openai/enableuserratelimit',
-        new lang_string('enableuserratelimit', 'aiprovider_openai'),
-        new lang_string('enableuserratelimit_desc', 'aiprovider_openai'),
+        'aiprovider_openrouter/enableuserratelimit',
+        new lang_string('enableuserratelimit', 'aiprovider_openrouter'),
+        new lang_string('enableuserratelimit_desc', 'aiprovider_openrouter'),
         0,
     ));
 
     // Setting to set how many requests per hour are allowed for the user rate limit.
     // Should only be enabled when user rate limiting is enabled.
     $settings->add(new admin_setting_configtext(
-        'aiprovider_openai/userratelimit',
-        new lang_string('userratelimit', 'aiprovider_openai'),
-        new lang_string('userratelimit_desc', 'aiprovider_openai'),
+        'aiprovider_openrouter/userratelimit',
+        new lang_string('userratelimit', 'aiprovider_openrouter'),
+        new lang_string('userratelimit_desc', 'aiprovider_openrouter'),
         10,
         PARAM_INT,
     ));
-    $settings->hide_if('aiprovider_openai/userratelimit', 'aiprovider_openai/enableuserratelimit', 'eq', 0);
+    $settings->hide_if('aiprovider_openrouter/userratelimit', 'aiprovider_openrouter/enableuserratelimit', 'eq', 0);
 }

--- a/tests/process_generate_text_test.php
+++ b/tests/process_generate_text_test.php
@@ -14,22 +14,23 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace aiprovider_openai;
+namespace aiprovider_openrouter;
 
-use aiprovider_openai\process_generate_text;
+use aiprovider_openrouter\process_generate_text;
 use core_ai\aiactions\base;
 use core_ai\provider;
 use GuzzleHttp\Psr7\Response;
 
 /**
- * Test Generate text provider class for OpenAI provider methods.
+ * Test Generate text provider class for OpenRouter provider methods.
  *
- * @package    aiprovider_openai
+ * @package    aiprovider_openrouter
+ * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
  * @copyright  2024 Matt Porritt <matt.porritt@moodle.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @covers     \aiprovider_openai\provider
- * @covers     \aiprovider_openai\process_generate_text
- * @covers     \aiprovider_openai\abstract_processor
+ * @covers     \aiprovider_openrouter\provider
+ * @covers     \aiprovider_openrouter\process_generate_text
+ * @covers     \aiprovider_openrouter\abstract_processor
  */
 final class process_generate_text_test extends \advanced_testcase {
     /** @var string A successful response in JSON format. */
@@ -47,7 +48,9 @@ final class process_generate_text_test extends \advanced_testcase {
     protected function setUp(): void {
         parent::setUp();
         // Load a response body from a file.
-        $this->responsebodyjson = file_get_contents(self::get_fixture_path('aiprovider_openai', 'text_request_success.json'));
+        $this->responsebodyjson = file_get_contents(self::get_fixture_path('aiprovider_openrouter', 'text_request_success.json'));
+        set_config('action_generate_text_model', 'openrouter/auto', 'aiprovider_openrouter');
+        set_config('action_generate_text_endpoint', 'https://openrouter.ai/api/v1/chat/completions', 'aiprovider_openrouter');
         $this->create_provider();
         $this->create_action();
     }
@@ -56,7 +59,7 @@ final class process_generate_text_test extends \advanced_testcase {
      * Create the provider object.
      */
     private function create_provider(): void {
-        $this->provider = new \aiprovider_openai\provider();
+        $this->provider = new \aiprovider_openrouter\provider();
     }
 
     /**
@@ -122,7 +125,8 @@ final class process_generate_text_test extends \advanced_testcase {
             } else if ($status == 503) {
                 $this->assertEquals('Service Unavailable', $result['errormessage']);
             } else {
-                $this->assertStringContainsString($response->getBody()->getContents(), $result['errormessage']);
+                $expectedmessage = $response->getBody()->getContents();
+                $this->assertStringContainsString($expectedmessage, $result['errormessage']);
             }
         }
     }
@@ -148,8 +152,8 @@ final class process_generate_text_test extends \advanced_testcase {
         $this->assertEquals('fp_c4e5b6fa31', $result['fingerprint']);
         $this->assertStringContainsString('Sure, here is some sample text', $result['generatedcontent']);
         $this->assertEquals('stop', $result['finishreason']);
-        $this->assertEquals('11', $result['prompttokens']);
-        $this->assertEquals('568', $result['completiontokens']);
+        $this->assertEquals(11, $result['prompttokens']);
+        $this->assertEquals(568, $result['completiontokens']);
 
     }
 
@@ -176,8 +180,8 @@ final class process_generate_text_test extends \advanced_testcase {
         $this->assertEquals('fp_c4e5b6fa31', $result['fingerprint']);
         $this->assertStringContainsString('Sure, here is some sample text', $result['generatedcontent']);
         $this->assertEquals('stop', $result['finishreason']);
-        $this->assertEquals('11', $result['prompttokens']);
-        $this->assertEquals('568', $result['completiontokens']);
+        $this->assertEquals(11, $result['prompttokens']);
+        $this->assertEquals(568, $result['completiontokens']);
     }
 
     /**
@@ -195,8 +199,8 @@ final class process_generate_text_test extends \advanced_testcase {
             'fingerprint' => 'fp_c4e5b6fa31',
             'generatedcontent' => 'Sure, here is some sample text',
             'finishreason' => 'stop',
-            'prompttokens' => '11',
-            'completiontokens' => '568',
+            'prompttokens' => 11,
+            'completiontokens' => 568,
         ];
 
         $result = $method->invoke($processor, $response);
@@ -300,8 +304,8 @@ final class process_generate_text_test extends \advanced_testcase {
         $clock = $this->mock_clock_with_frozen();
 
         // Set the user rate limiter.
-        set_config('enableuserratelimit', 1, 'aiprovider_openai');
-        set_config('userratelimit', 1, 'aiprovider_openai');
+        set_config('enableuserratelimit', 1, 'aiprovider_openrouter');
+        set_config('userratelimit', 1, 'aiprovider_openrouter');
 
         // Mock the http client to return a successful response.
         ['mock' => $mock] = $this->get_mocked_http_client();
@@ -381,8 +385,8 @@ final class process_generate_text_test extends \advanced_testcase {
         $clock = $this->mock_clock_with_frozen();
 
         // Set the global rate limiter.
-        set_config('enableglobalratelimit', 1, 'aiprovider_openai');
-        set_config('globalratelimit', 1, 'aiprovider_openai');
+        set_config('enableglobalratelimit', 1, 'aiprovider_openrouter');
+        set_config('globalratelimit', 1, 'aiprovider_openrouter');
 
         // Mock the http client to return a successful response.
         ['mock' => $mock] = $this->get_mocked_http_client();

--- a/tests/process_summarise_text_test.php
+++ b/tests/process_summarise_text_test.php
@@ -14,22 +14,23 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace aiprovider_openai;
+namespace aiprovider_openrouter;
 
-use aiprovider_openai\process_summarise_text;
+use aiprovider_openrouter\process_summarise_text;
 use core_ai\aiactions\base;
 use core_ai\provider;
 use GuzzleHttp\Psr7\Response;
 
 /**
- * Test Generate text provider class for OpenAI provider methods.
+ * Test Generate text provider class for OpenRouter provider methods.
  *
- * @package    aiprovider_openai
+ * @package    aiprovider_openrouter
+ * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
  * @copyright  2024 Matt Porritt <matt.porritt@moodle.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @covers     \aiprovider_openai\provider
- * @covers     \aiprovider_openai\process_summarise_text
- * @covers     \aiprovider_openai\abstract_processor
+ * @covers     \aiprovider_openrouter\provider
+ * @covers     \aiprovider_openrouter\process_summarise_text
+ * @covers     \aiprovider_openrouter\abstract_processor
  */
 final class process_summarise_text_test extends \advanced_testcase {
     /** @var string A successful response in JSON format. */
@@ -47,7 +48,9 @@ final class process_summarise_text_test extends \advanced_testcase {
     protected function setUp(): void {
         parent::setUp();
         // Load a response body from a file.
-        $this->responsebodyjson = file_get_contents(self::get_fixture_path('aiprovider_openai', 'text_request_success.json'));
+        $this->responsebodyjson = file_get_contents(self::get_fixture_path('aiprovider_openrouter', 'text_request_success.json'));
+        set_config('action_summarise_text_model', 'openrouter/auto', 'aiprovider_openrouter');
+        set_config('action_summarise_text_endpoint', 'https://openrouter.ai/api/v1/chat/completions', 'aiprovider_openrouter');
         $this->create_provider();
         $this->create_action();
     }
@@ -56,7 +59,7 @@ final class process_summarise_text_test extends \advanced_testcase {
      * Create the provider object.
      */
     private function create_provider(): void {
-        $this->provider = new \aiprovider_openai\provider();
+        $this->provider = new \aiprovider_openrouter\provider();
     }
 
     /**
@@ -116,7 +119,8 @@ final class process_summarise_text_test extends \advanced_testcase {
             } else if ($status == 503) {
                 $this->assertEquals('Service Unavailable', $result['errormessage']);
             } else {
-                $this->assertStringContainsString($response->getBody()->getContents(), $result['errormessage']);
+                $expectedmessage = $response->getBody()->getContents();
+                $this->assertStringContainsString($expectedmessage, $result['errormessage']);
             }
         }
     }
@@ -142,8 +146,8 @@ final class process_summarise_text_test extends \advanced_testcase {
         $this->assertEquals('fp_c4e5b6fa31', $result['fingerprint']);
         $this->assertStringContainsString('Sure, here is some sample text', $result['generatedcontent']);
         $this->assertEquals('stop', $result['finishreason']);
-        $this->assertEquals('11', $result['prompttokens']);
-        $this->assertEquals('568', $result['completiontokens']);
+        $this->assertEquals(11, $result['prompttokens']);
+        $this->assertEquals(568, $result['completiontokens']);
 
     }
 
@@ -170,8 +174,8 @@ final class process_summarise_text_test extends \advanced_testcase {
         $this->assertEquals('fp_c4e5b6fa31', $result['fingerprint']);
         $this->assertStringContainsString('Sure, here is some sample text', $result['generatedcontent']);
         $this->assertEquals('stop', $result['finishreason']);
-        $this->assertEquals('11', $result['prompttokens']);
-        $this->assertEquals('568', $result['completiontokens']);
+        $this->assertEquals(11, $result['prompttokens']);
+        $this->assertEquals(568, $result['completiontokens']);
     }
 
     /**
@@ -189,8 +193,8 @@ final class process_summarise_text_test extends \advanced_testcase {
             'fingerprint' => 'fp_c4e5b6fa31',
             'generatedcontent' => 'Sure, here is some sample text',
             'finishreason' => 'stop',
-            'prompttokens' => '11',
-            'completiontokens' => '568',
+            'prompttokens' => 11,
+            'completiontokens' => 568,
         ];
 
         $result = $method->invoke($processor, $response);
@@ -294,8 +298,8 @@ final class process_summarise_text_test extends \advanced_testcase {
         $clock = $this->mock_clock_with_frozen();
 
         // Set the user rate limiter.
-        set_config('enableuserratelimit', 1, 'aiprovider_openai');
-        set_config('userratelimit', 1, 'aiprovider_openai');
+        set_config('enableuserratelimit', 1, 'aiprovider_openrouter');
+        set_config('userratelimit', 1, 'aiprovider_openrouter');
 
         // Mock the http client to return a successful response.
         ['mock' => $mock] = $this->get_mocked_http_client();
@@ -375,8 +379,8 @@ final class process_summarise_text_test extends \advanced_testcase {
         $clock = $this->mock_clock_with_frozen();
 
         // Set the global rate limiter.
-        set_config('enableglobalratelimit', 1, 'aiprovider_openai');
-        set_config('globalratelimit', 1, 'aiprovider_openai');
+        set_config('enableglobalratelimit', 1, 'aiprovider_openrouter');
+        set_config('globalratelimit', 1, 'aiprovider_openrouter');
 
         // Mock the http client to return a successful response.
         ['mock' => $mock] = $this->get_mocked_http_client();

--- a/tests/provider_test.php
+++ b/tests/provider_test.php
@@ -14,15 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace aiprovider_openai;
+namespace aiprovider_openrouter;
+
+use GuzzleHttp\Psr7\Request;
 
 /**
- * Test OpenAI provider methods.
+ * Test OpenRouter provider methods.
  *
- * @package    aiprovider_openai
+ * @package    aiprovider_openrouter
+ * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
  * @copyright  2024 Matt Porritt <matt.porritt@moodle.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @covers     \aiprovider_openai\provider
+ * @covers     \aiprovider_openrouter\provider
  */
 final class provider_test extends \advanced_testcase {
     /**
@@ -51,16 +54,35 @@ final class provider_test extends \advanced_testcase {
     }
 
     /**
+     * Test add_authentication_headers.
+     */
+    public function test_add_authentication_headers(): void {
+        $this->resetAfterTest();
+
+        set_config('apikey', 'secret-key', 'aiprovider_openrouter');
+        set_config('httpreferer', 'https://example.com', 'aiprovider_openrouter');
+        set_config('xtitle', 'Example Moodle', 'aiprovider_openrouter');
+
+        $provider = new provider();
+        $request = new Request('GET', 'https://openrouter.ai/api/v1/chat/completions');
+        $updatedrequest = $provider->add_authentication_headers($request);
+
+        $this->assertEquals('Bearer secret-key', $updatedrequest->getHeaderLine('Authorization'));
+        $this->assertEquals('https://example.com', $updatedrequest->getHeaderLine('HTTP-Referer'));
+        $this->assertEquals('Example Moodle', $updatedrequest->getHeaderLine('X-Title'));
+    }
+
+    /**
      * Test is_request_allowed.
      */
     public function test_is_request_allowed(): void {
         $this->resetAfterTest();
 
         // Set plugin config rate limiter settings.
-        set_config('enableglobalratelimit', 1, 'aiprovider_openai');
-        set_config('globalratelimit', 5, 'aiprovider_openai');
-        set_config('enableuserratelimit', 1, 'aiprovider_openai');
-        set_config('userratelimit', 3, 'aiprovider_openai');
+        set_config('enableglobalratelimit', 1, 'aiprovider_openrouter');
+        set_config('globalratelimit', 5, 'aiprovider_openrouter');
+        set_config('enableuserratelimit', 1, 'aiprovider_openrouter');
+        set_config('userratelimit', 3, 'aiprovider_openrouter');
 
         $contextid = 1;
         $userid = 1;
@@ -118,12 +140,12 @@ final class provider_test extends \advanced_testcase {
         $this->resetAfterTest();
 
         // No configured values.
-        $provider = new \aiprovider_openai\provider();
+        $provider = new \aiprovider_openrouter\provider();
         $this->assertFalse($provider->is_provider_configured());
 
         // Properly configured values.
-        set_config('apikey', '123', 'aiprovider_openai');
-        $provider = new \aiprovider_openai\provider();
+        set_config('apikey', '123', 'aiprovider_openrouter');
+        $provider = new \aiprovider_openrouter\provider();
         $this->assertTrue($provider->is_provider_configured());
     }
 }


### PR DESCRIPTION
Update the AI provider from OpenAI to OpenRouter, including namespace changes, configuration updates, and an upgrade script for legacy data migration. Add comprehensive documentation for the new provider's features and installation instructions.