### PR TITLE
Set release version to 1.0.0 for OpenRouter AI provider

### DIFF
--- a/version.php
+++ b/version.php
@@ -28,4 +28,5 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->component = 'aiprovider_openrouter';
 $plugin->version = 2024100701;
 $plugin->requires = 2024100100;
+$plugin->release = '1.0.0';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Update the release version for the OpenRouter AI provider to 1.0.0.