### PR TITLE
Fix/moodle 5 provider api compatibility

### DIFF
--- a/classes/form/action_form.php
+++ b/classes/form/action_form.php
@@ -1,0 +1,54 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace aiprovider_openrouter\form;
+
+use core_ai\form\action_settings_form;
+
+/**
+ * Base action settings form for OpenRouter provider.
+ *
+ * @package    aiprovider_openrouter
+ * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class action_form extends action_settings_form {
+    /** @var array Action configuration. */
+    protected array $actionconfig;
+    /** @var string|null Return URL. */
+    protected ?string $returnurl;
+    /** @var string Action name. */
+    protected string $actionname;
+    /** @var string Action class. */
+    protected string $action;
+    /** @var int Provider ID. */
+    protected int $providerid;
+    /** @var string Provider name. */
+    protected string $providername;
+
+    #[\Override]
+    protected function definition(): void {
+        $mform = $this->_form;
+        $this->actionconfig = $this->_customdata['actionconfig']['settings'] ?? [];
+        $this->returnurl = $this->_customdata['returnurl'] ?? null;
+        $this->actionname = $this->_customdata['actionname'];
+        $this->action = $this->_customdata['action'];
+        $this->providerid = $this->_customdata['providerid'] ?? 0;
+        $this->providername = $this->_customdata['providername'] ?? 'aiprovider_openrouter';
+
+        $mform->addElement('header', 'generalsettingsheader', get_string('general', 'core'));
+    }
+}

--- a/classes/form/action_generate_image_form.php
+++ b/classes/form/action_generate_image_form.php
@@ -1,0 +1,68 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace aiprovider_openrouter\form;
+
+/**
+ * Generate image action settings form for OpenRouter provider.
+ *
+ * @package    aiprovider_openrouter
+ * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class action_generate_image_form extends action_form {
+    #[\Override]
+    protected function definition(): void {
+        parent::definition();
+        $mform = $this->_form;
+
+        $mform->addElement(
+            'text',
+            'model',
+            get_string("action:{$this->actionname}:model", 'aiprovider_openrouter'),
+            'maxlength="255" size="40"',
+        );
+        $mform->setType('model', PARAM_TEXT);
+        $mform->addRule('model', null, 'required', null, 'client');
+        $mform->setDefault('model', $this->actionconfig['model'] ?? 'openai/dall-e-3');
+
+        $mform->addElement(
+            'text',
+            'endpoint',
+            get_string("action:{$this->actionname}:endpoint", 'aiprovider_openrouter'),
+            'maxlength="255" size="60"',
+        );
+        $mform->setType('endpoint', PARAM_URL);
+        $mform->addRule('endpoint', null, 'required', null, 'client');
+        $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? 'https://openrouter.ai/api/v1/images/generations');
+
+        if ($this->returnurl) {
+            $mform->addElement('hidden', 'returnurl', $this->returnurl);
+            $mform->setType('returnurl', PARAM_LOCALURL);
+        }
+
+        $mform->addElement('hidden', 'action', $this->action);
+        $mform->setType('action', PARAM_TEXT);
+
+        $mform->addElement('hidden', 'provider', $this->providername);
+        $mform->setType('provider', PARAM_TEXT);
+
+        $mform->addElement('hidden', 'providerid', $this->providerid);
+        $mform->setType('providerid', PARAM_INT);
+
+        $this->set_data($this->actionconfig);
+    }
+}

--- a/classes/form/action_generate_text_form.php
+++ b/classes/form/action_generate_text_form.php
@@ -1,0 +1,80 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace aiprovider_openrouter\form;
+
+/**
+ * Generate/summarise text action settings form for OpenRouter provider.
+ *
+ * @package    aiprovider_openrouter
+ * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class action_generate_text_form extends action_form {
+    #[\Override]
+    protected function definition(): void {
+        parent::definition();
+        $mform = $this->_form;
+
+        $mform->addElement(
+            'text',
+            'model',
+            get_string("action:{$this->actionname}:model", 'aiprovider_openrouter'),
+            'maxlength="255" size="40"',
+        );
+        $mform->setType('model', PARAM_TEXT);
+        $mform->addRule('model', null, 'required', null, 'client');
+        $mform->setDefault('model', $this->actionconfig['model'] ?? 'openrouter/auto');
+
+        $mform->addElement(
+            'text',
+            'endpoint',
+            get_string("action:{$this->actionname}:endpoint", 'aiprovider_openrouter'),
+            'maxlength="255" size="60"',
+        );
+        $mform->setType('endpoint', PARAM_URL);
+        $mform->addRule('endpoint', null, 'required', null, 'client');
+        $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? 'https://openrouter.ai/api/v1/chat/completions');
+
+        $mform->addElement(
+            'textarea',
+            'systeminstruction',
+            get_string("action:{$this->actionname}:systeminstruction", 'aiprovider_openrouter'),
+            'wrap="virtual" rows="5" cols="60"',
+        );
+        $mform->setType('systeminstruction', PARAM_TEXT);
+        $defaultinstruction = !empty($this->actionconfig['systeminstruction'])
+            ? $this->actionconfig['systeminstruction']
+            : $this->action::get_system_instruction();
+        $mform->setDefault('systeminstruction', $defaultinstruction);
+
+        if ($this->returnurl) {
+            $mform->addElement('hidden', 'returnurl', $this->returnurl);
+            $mform->setType('returnurl', PARAM_LOCALURL);
+        }
+
+        $mform->addElement('hidden', 'action', $this->action);
+        $mform->setType('action', PARAM_TEXT);
+
+        $mform->addElement('hidden', 'provider', $this->providername);
+        $mform->setType('provider', PARAM_TEXT);
+
+        $mform->addElement('hidden', 'providerid', $this->providerid);
+        $mform->setType('providerid', PARAM_INT);
+
+        $this->set_data($this->actionconfig);
+    }
+}

--- a/classes/hook_listener.php
+++ b/classes/hook_listener.php
@@ -1,0 +1,84 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace aiprovider_openrouter;
+
+use core_ai\hook\after_ai_provider_form_hook;
+
+/**
+ * Hook listener for OpenRouter provider.
+ *
+ * @package    aiprovider_openrouter
+ * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class hook_listener {
+
+    /**
+     * Hook listener for the OpenRouter instance setup form.
+     *
+     * @param after_ai_provider_form_hook $hook
+     */
+    public static function set_form_definition_for_aiprovider_openrouter(after_ai_provider_form_hook $hook): void {
+        if ($hook->plugin !== 'aiprovider_openrouter') {
+            return;
+        }
+
+        $mform = $hook->mform;
+
+        $mform->addElement(
+            'passwordunmask',
+            'apikey',
+            get_string('apikey', 'aiprovider_openrouter'),
+            ['size' => 75],
+        );
+        $mform->addRule('apikey', get_string('required'), 'required', null, 'client');
+        $mform->addElement(
+            'static',
+            'apikey_help',
+            '',
+            get_string('apikey_desc', 'aiprovider_openrouter'),
+        );
+
+        $mform->addElement(
+            'text',
+            'httpreferer',
+            get_string('httpreferer', 'aiprovider_openrouter'),
+            ['size' => 60],
+        );
+        $mform->setType('httpreferer', PARAM_URL);
+        $mform->addElement(
+            'static',
+            'httpreferer_help',
+            '',
+            get_string('httpreferer_desc', 'aiprovider_openrouter'),
+        );
+
+        $mform->addElement(
+            'text',
+            'xtitle',
+            get_string('xtitle', 'aiprovider_openrouter'),
+            ['size' => 60],
+        );
+        $mform->setType('xtitle', PARAM_TEXT);
+        $mform->addElement(
+            'static',
+            'xtitle_help',
+            '',
+            get_string('xtitle_desc', 'aiprovider_openrouter'),
+        );
+    }
+}

--- a/classes/process_generate_image.php
+++ b/classes/process_generate_image.php
@@ -41,12 +41,14 @@ class process_generate_image extends abstract_processor {
 
     #[\Override]
     protected function get_endpoint(): UriInterface {
-        return new Uri(get_config('aiprovider_openrouter', 'action_generate_image_endpoint'));
+        $settings = $this->provider->actionconfig[$this->action::class]['settings'] ?? [];
+        return new Uri($settings['endpoint'] ?? 'https://openrouter.ai/api/v1/images/generations');
     }
 
     #[\Override]
     protected function get_model(): string {
-        return get_config('aiprovider_openrouter', 'action_generate_image_model');
+        $settings = $this->provider->actionconfig[$this->action::class]['settings'] ?? [];
+        return $settings['model'] ?? 'openai/dall-e-3';
     }
 
     #[\Override]

--- a/classes/process_generate_text.php
+++ b/classes/process_generate_text.php
@@ -33,17 +33,20 @@ use Psr\Http\Message\UriInterface;
 class process_generate_text extends abstract_processor {
     #[\Override]
     protected function get_endpoint(): UriInterface {
-        return new Uri(get_config('aiprovider_openrouter', 'action_generate_text_endpoint'));
+        $settings = $this->provider->actionconfig[$this->action::class]['settings'] ?? [];
+        return new Uri($settings['endpoint'] ?? 'https://openrouter.ai/api/v1/chat/completions');
     }
 
     #[\Override]
     protected function get_model(): string {
-        return get_config('aiprovider_openrouter', 'action_generate_text_model');
+        $settings = $this->provider->actionconfig[$this->action::class]['settings'] ?? [];
+        return $settings['model'] ?? 'openrouter/auto';
     }
 
     #[\Override]
     protected function get_system_instruction(): string {
-        return get_config('aiprovider_openrouter', 'action_generate_text_systeminstruction');
+        $settings = $this->provider->actionconfig[$this->action::class]['settings'] ?? [];
+        return $settings['systeminstruction'] ?? $this->action::get_system_instruction();
     }
 
     #[\Override]

--- a/classes/process_summarise_text.php
+++ b/classes/process_summarise_text.php
@@ -30,16 +30,19 @@ use Psr\Http\Message\UriInterface;
 class process_summarise_text extends process_generate_text {
     #[\Override]
     protected function get_endpoint(): UriInterface {
-        return new Uri(get_config('aiprovider_openrouter', 'action_summarise_text_endpoint'));
+        $settings = $this->provider->actionconfig[$this->action::class]['settings'] ?? [];
+        return new Uri($settings['endpoint'] ?? 'https://openrouter.ai/api/v1/chat/completions');
     }
 
     #[\Override]
     protected function get_model(): string {
-        return get_config('aiprovider_openrouter', 'action_summarise_text_model');
+        $settings = $this->provider->actionconfig[$this->action::class]['settings'] ?? [];
+        return $settings['model'] ?? 'openrouter/auto';
     }
 
     #[\Override]
     protected function get_system_instruction(): string {
-        return get_config('aiprovider_openrouter', 'action_summarise_text_systeminstruction');
+        $settings = $this->provider->actionconfig[$this->action::class]['settings'] ?? [];
+        return $settings['systeminstruction'] ?? $this->action::get_system_instruction();
     }
 }

--- a/classes/provider.php
+++ b/classes/provider.php
@@ -16,8 +16,7 @@
 
 namespace aiprovider_openrouter;
 
-use core_ai\aiactions;
-use core_ai\rate_limiter;
+use core_ai\form\action_settings_form;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -29,59 +28,13 @@ use Psr\Http\Message\RequestInterface;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class provider extends \core_ai\provider {
-    /** @var string The OpenRouter API key. */
-    private string $apikey;
-
-    /** @var string Value sent as HTTP-Referer header required by OpenRouter. */
-    private string $httpreferer;
-
-    /** @var string Value sent as X-Title header recommended by OpenRouter. */
-    private string $xtitle;
-
-    /** @var bool Is global rate limiting for the API enabled. */
-    private bool $enableglobalratelimit;
-
-    /** @var int The global rate limit. */
-    private int $globalratelimit;
-
-    /** @var bool Is user rate limiting for the API enabled */
-    private bool $enableuserratelimit;
-
-    /** @var int The user rate limit. */
-    private int $userratelimit;
-
-    /**
-     * Class constructor.
-     */
-    public function __construct() {
-        global $CFG;
-        // Get api key from config.
-        $this->apikey = get_config('aiprovider_openrouter', 'apikey');
-        // Get headers from config, falling back to sensible defaults.
-        $this->httpreferer = get_config('aiprovider_openrouter', 'httpreferer') ?: $CFG->wwwroot;
-        $defaulttitle = get_config('moodle', 'sitename') ?: 'Moodle';
-        $this->xtitle = get_config('aiprovider_openrouter', 'xtitle') ?: $defaulttitle;
-        // Legacy support for the old organisation id config.
-        if (empty($this->httpreferer)) {
-            $legacyorgid = get_config('aiprovider_openrouter', 'orgid');
-            if (!empty($legacyorgid)) {
-                $this->httpreferer = $legacyorgid;
-            }
-        }
-        // Get global rate limit from config.
-        $this->enableglobalratelimit = get_config('aiprovider_openrouter', 'enableglobalratelimit');
-        $this->globalratelimit = get_config('aiprovider_openrouter', 'globalratelimit');
-        // Get user rate limit from config.
-        $this->enableuserratelimit = get_config('aiprovider_openrouter', 'enableuserratelimit');
-        $this->userratelimit = get_config('aiprovider_openrouter', 'userratelimit');
-    }
 
     /**
      * Get the list of actions that this provider supports.
      *
      * @return array An array of action class names.
      */
-    public function get_action_list(): array {
+    public static function get_action_list(): array {
         return [
             \core_ai\aiactions\generate_text::class,
             \core_ai\aiactions\generate_image::class,
@@ -89,146 +42,56 @@ class provider extends \core_ai\provider {
         ];
     }
 
-    /**
-     * Generate a user id.
-     *
-     * This is a hash of the site id and user id,
-     * this means we can determine who made the request
-     * but don't pass any personal data to OpenAI.
-     *
-     * @param string $userid The user id.
-     * @return string The generated user id.
-     */
-    public function generate_userid(string $userid): string {
-        global $CFG;
-        return hash('sha256', $CFG->siteidentifier . $userid);
-    }
-
-    /**
-     * Update a request to add any headers required by the provider.
-     *
-     * @param \Psr\Http\Message\RequestInterface $request
-     * @return \Psr\Http\Message\RequestInterface
-     */
+    #[\Override]
     public function add_authentication_headers(RequestInterface $request): RequestInterface {
-        $request = $request->withAddedHeader('Authorization', "Bearer {$this->apikey}");
-        if (!empty($this->httpreferer)) {
-            $request = $request->withAddedHeader('HTTP-Referer', $this->httpreferer);
+        $request = $request->withAddedHeader('Authorization', "Bearer {$this->config['apikey']}");
+        $httpreferer = $this->config['httpreferer'] ?? '';
+        if (!empty($httpreferer)) {
+            $request = $request->withAddedHeader('HTTP-Referer', $httpreferer);
         }
-        if (!empty($this->xtitle)) {
-            $request = $request->withAddedHeader('X-Title', $this->xtitle);
+        $xtitle = $this->config['xtitle'] ?? '';
+        if (!empty($xtitle)) {
+            $request = $request->withAddedHeader('X-Title', $xtitle);
         }
-
         return $request;
     }
 
     #[\Override]
-    public function is_request_allowed(aiactions\base $action): array|bool {
-        $ratelimiter = \core\di::get(rate_limiter::class);
-        $component = \core\component::get_component_from_classname(get_class($this));
-
-        // Check the user rate limit.
-        if ($this->enableuserratelimit) {
-            if (!$ratelimiter->check_user_rate_limit(
-                component: $component,
-                ratelimit: $this->userratelimit,
-                userid: $action->get_configuration('userid')
-            )) {
-                return [
-                    'success' => false,
-                    'errorcode' => 429,
-                    'errormessage' => 'User rate limit exceeded',
-                ];
-            }
-        }
-
-        // Check the global rate limit.
-        if ($this->enableglobalratelimit) {
-            if (!$ratelimiter->check_global_rate_limit(
-                component: $component,
-                ratelimit: $this->globalratelimit
-            )) {
-                return [
-                    'success' => false,
-                    'errorcode' => 429,
-                    'errormessage' => 'Global rate limit exceeded',
-                ];
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Get any action settings for this provider.
-     *
-     * @param string $action The action class name.
-     * @param \admin_root $ADMIN The admin root object.
-     * @param string $section The section name.
-     * @param bool $hassiteconfig Whether the current user has moodle/site:config capability.
-     * @return array An array of settings.
-     */
-    public function get_action_settings(
+    public static function get_action_settings(
         string $action,
-        \admin_root $ADMIN,
-        string $section,
-        bool $hassiteconfig
-    ): array {
+        array $customdata = [],
+    ): action_settings_form|bool {
         $actionname = substr($action, (strrpos($action, '\\') + 1));
-        $settings = [];
+        $customdata['actionname'] = $actionname;
+        $customdata['action'] = $action;
         if ($actionname === 'generate_text' || $actionname === 'summarise_text') {
-            // Add the model setting.
-            $settings[] = new \admin_setting_configtext(
-                "aiprovider_openrouter/action_{$actionname}_model",
-                new \lang_string("action:{$actionname}:model", 'aiprovider_openrouter'),
-                new \lang_string("action:{$actionname}:model_desc", 'aiprovider_openrouter'),
-                'openrouter/auto',
-                PARAM_TEXT,
-            );
-            // Add API endpoint.
-            $settings[] = new \admin_setting_configtext(
-                "aiprovider_openrouter/action_{$actionname}_endpoint",
-                new \lang_string("action:{$actionname}:endpoint", 'aiprovider_openrouter'),
-                '',
-                'https://openrouter.ai/api/v1/chat/completions',
-                PARAM_URL,
-            );
-            // Add system instruction settings.
-            $settings[] = new \admin_setting_configtextarea(
-                "aiprovider_openrouter/action_{$actionname}_systeminstruction",
-                new \lang_string("action:{$actionname}:systeminstruction", 'aiprovider_openrouter'),
-                new \lang_string("action:{$actionname}:systeminstruction_desc", 'aiprovider_openrouter'),
-                $action::get_system_instruction(),
-                PARAM_TEXT
-            );
+            return new form\action_generate_text_form(customdata: $customdata);
         } else if ($actionname === 'generate_image') {
-            // Add the model setting.
-            $settings[] = new \admin_setting_configtext(
-                "aiprovider_openrouter/action_{$actionname}_model",
-                new \lang_string("action:{$actionname}:model", 'aiprovider_openrouter'),
-                new \lang_string("action:{$actionname}:model_desc", 'aiprovider_openrouter'),
-                'openai/dall-e-3',
-                PARAM_TEXT,
-            );
-            // Add API endpoint.
-            $settings[] = new \admin_setting_configtext(
-                "aiprovider_openrouter/action_{$actionname}_endpoint",
-                new \lang_string("action:{$actionname}:endpoint", 'aiprovider_openrouter'),
-                '',
-                'https://openrouter.ai/api/v1/images/generations',
-                PARAM_URL,
-            );
+            return new form\action_generate_image_form(customdata: $customdata);
         }
-
-        return $settings;
+        return false;
     }
 
-    /**
-     * Check this provider has the minimal configuration to work.
-     *
-     * @return bool Return true if configured.
-     */
+    #[\Override]
+    public static function get_action_setting_defaults(string $action): array {
+        $actionname = substr($action, (strrpos($action, '\\') + 1));
+        $customdata = [
+            'actionname' => $actionname,
+            'action' => $action,
+            'providername' => 'aiprovider_openrouter',
+        ];
+        if ($actionname === 'generate_text' || $actionname === 'summarise_text') {
+            $mform = new form\action_generate_text_form(customdata: $customdata);
+            return $mform->get_defaults();
+        } else if ($actionname === 'generate_image') {
+            $mform = new form\action_generate_image_form(customdata: $customdata);
+            return $mform->get_defaults();
+        }
+        return [];
+    }
+
+    #[\Override]
     public function is_provider_configured(): bool {
-        return !empty($this->apikey);
+        return !empty($this->config['apikey']);
     }
 }

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of Moodle - https://moodle.org/
+// This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,18 +12,21 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Plugin administration pages are defined here.
+ * Hook listener callbacks for the OpenRouter provider.
  *
- * In Moodle 5.0+ all provider configuration (API key, headers, rate limits,
- * action settings) is stored per-instance via the AI configure page at
- * /ai/configure.php. There are no global plugin-level settings.
- *
- * @package     aiprovider_openrouter
- * @copyright   2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
- * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package    aiprovider_openrouter
+ * @copyright  2025 e-Learning Team, Universiti Malaysia Terengganu <el@umt.edu.my>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
+
+$callbacks = [
+    [
+        'hook' => \core_ai\hook\after_ai_provider_form_hook::class,
+        'callback' => \aiprovider_openrouter\hook_listener::class . '::set_form_definition_for_aiprovider_openrouter',
+    ],
+];

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'aiprovider_openrouter';
-$plugin->version = 2025041400;
-$plugin->requires = 2024100700;  // Moodle 4.5+
-$plugin->release = '1.1.0';
+$plugin->version = 2026052800;
+$plugin->requires = 2025041400;  // Moodle 5.0+
+$plugin->release = '2.0.0';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
this PR fixes the error 500 when trying to add an Openrouter AI Provider in Moodle 5.0.x (not tested on higher versions though). Took the liberty to bump version to 2.0.0 since moodle 4.x no longer compatible. Feel free to change as you see fit.

this fixes #19 and probably also #20 

Disclaimer: This was done with Claude Code and tested on Moodle 5.0.7

---

Moodle 5.0 redesigned the core_ai\provider architecture: the constructor
now accepts per-instance config as a JSON blob, form fields are registered
via a hook system, and action settings use moodleform classes instead of
admin_setting objects.

- Remove bespoke constructor; config now accessed via $this->config[]
- Make get_action_list() static per new interface contract
- Add db/hooks.php + hook_listener.php to inject API key, HTTP-Referer
  and X-Title fields into the provider create/edit form
- Add classes/form/ with action settings forms for text and image actions
- Add get_action_settings() and get_action_setting_defaults() with correct
  Moodle 5.0 signatures
- Update process_* classes to read model/endpoint/systeminstruction from
  $this->provider->actionconfig instead of get_config()
- Clear settings.php: per-instance config is stored in the DB via the
  new form system, not in global plugin settings

